### PR TITLE
Dakota/federated livestream refactor

### DIFF
--- a/server/src/federation/requestUpdate.js
+++ b/server/src/federation/requestUpdate.js
@@ -5,7 +5,7 @@ async function requestUpdate(payload) {
         fedID: payload.fedPublicId,
         stmName: payload.name,
         stmDesc: payload.description,
-        stmPict: payload.picture,
+        stmPict: payload.photo,
     });
     const req = https.request({
         hostname: apiUrl,
@@ -29,7 +29,7 @@ async function requestUpdate(payload) {
 }   
 
 async function sendAllRequests(dataList) {
-    dataList.forEach((payload) => {
+    dataList.forEach(async (payload) => {
       try {
           await requestUpdate(payload);
       } catch (error) {

--- a/server/src/federation/requestUpdate.js
+++ b/server/src/federation/requestUpdate.js
@@ -1,8 +1,11 @@
 const https = require('https');
 
-async function requestUpdate(fedPublicId, apiUrl, apiPort) {
+async function requestUpdate(payload) {
     const postData = JSON.stringify({
-        fedID: fedPublicId,
+        fedID: payload.fedPublicId,
+        stmName: payload.name,
+        stmDesc: payload.description,
+        stmPict: payload.picture,
     });
     const req = https.request({
         hostname: apiUrl,
@@ -25,14 +28,14 @@ async function requestUpdate(fedPublicId, apiUrl, apiPort) {
     req.end();
 }   
 
-async function sendAllRequests(federation) {
-    for (let i = 0; i < federation.length; i++) {
-        try {
-            await requestUpdate(federation[i].fedPublicId, federation[i].apiUrl, federation[i].apiPort);
-        } catch (error) {
-            console.error(`Error sending requests: ${error}`);
-        }
-    }
+async function sendAllRequests(dataList) {
+    dataList.forEach((payload) => {
+      try {
+          await requestUpdate(payload);
+      } catch (error) {
+          console.error(`Error sending requests: ${error}`);
+      }
+    });
 }
 
 exports.sendAllRequests = sendAllRequests;

--- a/server/src/federation/requestUpdate.js
+++ b/server/src/federation/requestUpdate.js
@@ -1,11 +1,12 @@
 const https = require('https');
 
 async function requestUpdate(payload) {
+    const {fedPublicId, apiUrl, apiPort, title, description, photo} = payload 
     const postData = JSON.stringify({
-        fedID: payload.fedPublicId,
-        stmName: payload.name,
-        stmDesc: payload.description,
-        stmPict: payload.photo,
+        fedID: fedPublicId,
+        stmName: title,
+        stmDesc: description,
+        stmPict: photo,
     });
     const req = https.request({
         hostname: apiUrl,

--- a/server/src/models/federation.js
+++ b/server/src/models/federation.js
@@ -4,7 +4,7 @@ class Federation {
     static async getFederation() {
       try {
         const [results] = await pool.query(
-            "SELECT fedPublicId, apiUrl, apiPort FROM Federation",
+            "SELECT Federation.fedPublicId, Federation.apiUrl, Federation.apiPort, Streams.title, Streams.description, Streams.photo FROM Federation JOIN Streams ",
         );
         return results;
       } 

--- a/server/src/models/federation.js
+++ b/server/src/models/federation.js
@@ -4,7 +4,7 @@ class Federation {
     static async getFederation() {
       try {
         const [results] = await pool.query(
-            "SELECT Federation.fedPublicId, Federation.apiUrl, Federation.apiPort, Streams.title, Streams.description, Streams.photo FROM Federation JOIN Streams ",
+            "SELECT Federation.fedPublicId, Federation.apiUrl, Federation.apiPort, Streams.title, Streams.description, Streams.photo FROM Federation JOIN Streams WHERE Streams.id = 1",
         );
         return results;
       } 

--- a/server/src/models/federation.js
+++ b/server/src/models/federation.js
@@ -2,10 +2,16 @@ const pool = require("../db/db");
 
 class Federation {
     static async getFederation() {
+      try {
         const [results] = await pool.query(
             "SELECT fedPublicId, apiUrl, apiPort FROM Federation",
         );
         return results;
+      } 
+      catch(error) {
+      console.error(`Error getting federation: ${error}`);
+      return null;
+      }
     }
 
     static async setLiveFederation(req) {

--- a/server/src/models/federation.js
+++ b/server/src/models/federation.js
@@ -15,10 +15,10 @@ class Federation {
     }
 
     static async setLiveFederation(req) {
-        const { fedID } = req.body;
+        const { fedID, stmName, stmDesc, stmPict } = req.body;
         const [results] = await pool.query(
-            "UPDATE Streams SET isActive = 1 WHERE id = ?",
-            [fedID],
+            "UPDATE Streams SET title = ?, description = ?, photo = ?, isActive = 1 WHERE id = ?",
+            [stmName, stmDesc, stmPict, fedID],
         );
         return results;
     }

--- a/server/src/services/streamService.js
+++ b/server/src/services/streamService.js
@@ -11,7 +11,7 @@ const inputLink = "srt://localhost:2000?mode=listener";
 const outputPath = path.join(__dirname, "../../stream/streamout.m3u8");
 
 async function startFfmpegStream() {
-  const federation = await Federation.getFederation();
+  const federationList = await Federation.getFederation();
   ffmpeg(inputLink)
     .ffprobe((err, info) => {
       if (err) {
@@ -19,20 +19,22 @@ async function startFfmpegStream() {
         return;
       }
       else if (info) {
-        try {
-          // send information to federation.
-          console.log("updating federation.");
-        
-          // set the live stream to live = 1
-          Stream.startStream();
+        if(federationList !== null) {
+          try {
+            // send information to federation.
+            console.log("updating federation.");
+          
+            // set the live stream to live = 1
+            Stream.startStream();
 
-          console.log(`federation: ${federation}`);
+            console.log(`federation: ${federationList}`);
 
-          // send signal to federation that the server is live.
-          sendAllRequests(federation);
+            // send signal to federation that the server is live.
+            sendAllRequests(federationList);
 
-        } catch (error) {
-          console.error("error updating federation:", error);
+          } catch (error) {
+            console.error("error updating federation:", error);
+          }
         }
       }
       ffmpeg(inputLink)
@@ -49,11 +51,13 @@ async function startFfmpegStream() {
         .on("end", () => {
           console.log("finished");
           // delete previous stream files. set live stream to live = 0 and listen for new connection.
-          try { 
-            Stream.endStream();
+          if(federationList !== null) {
+            try { 
+              Stream.endStream();
 
-          } catch (error) {
-            console.error("error updating stream database:", error);
+            } catch (error) {
+              console.error("error updating stream database:", error);
+            }
           }
           console.log("informing federation stream is over.");
           startFfmpegStream();

--- a/server/src/services/streamService.js
+++ b/server/src/services/streamService.js
@@ -25,7 +25,6 @@ async function startFfmpegStream() {
           try {
             // send information to federation.
             //console.log("updating federation.");
-          
 
             //console.log(`federation: ${federationList}`);
 

--- a/server/src/services/streamService.js
+++ b/server/src/services/streamService.js
@@ -19,15 +19,15 @@ async function startFfmpegStream() {
         return;
       }
       else if (info) {
+        // set the live stream to live = 1
+        Stream.startStream();
         if(federationList !== null) {
           try {
             // send information to federation.
-            console.log("updating federation.");
+            //console.log("updating federation.");
           
-            // set the live stream to live = 1
-            Stream.startStream();
 
-            console.log(`federation: ${federationList}`);
+            //console.log(`federation: ${federationList}`);
 
             // send signal to federation that the server is live.
             sendAllRequests(federationList);


### PR DESCRIPTION
The livestream now pushes update data for federated instances of br3ezy. The JSON string (separated by string keys and the relational model of origin) now looks like:
```json
{
    "fedID": "Federated.fedId",
    "stmName": "Streams.title",
    "stmDesc": "Streams.description",
    "stmPict": "Streams.photo",
}
```

Also fixes a server crash that would occur if the Federation table in the MySQL server was empty.